### PR TITLE
added pan and zoom functionality

### DIFF
--- a/rest/server.coffee
+++ b/rest/server.coffee
@@ -24,7 +24,7 @@ app = express()
 
 # Enable body parser for json content. ``limit`` must not be larger than specified in
 # ``./web/conf/server.[dev/prod].json``
-app.use bodyParser.json limit: '10mb'
+app.use bodyParser.json limit: '20mb'
 
 # Root entry of REST server
 # -------------------------

--- a/web/app/core/diaModelBuilder.service.coffee
+++ b/web/app/core/diaModelBuilder.service.coffee
@@ -90,12 +90,14 @@ do ->
           end: input.end
           duration: input.duration
         input:
+          uuid: input.uuid
           inputs: input.inputs
           highlighter: input.highlighter
           image:
             path: input.image.url
             thumbPath: '<div class="project-members"><img src=\"' + input.image.thumbUrl + '\"></div>'
         output: output
+      result.output.uuid = input.uuid
 
       if angular.equals {}, result.input.inputs then result.input.inputs = null
       if angular.equals {}, result.input.highlighter then result.input.highlighter = null

--- a/web/app/core/diaProcessingQueue.service.coffee
+++ b/web/app/core/diaProcessingQueue.service.coffee
@@ -74,6 +74,7 @@ do ->
         item.start = moment(item.start).format 'HH:mm:ss'
         item.end = moment(end).format 'HH:mm:ss'
         item.duration = duration.toFixed(2)
+        item.uuid = end.getTime()
         $rootScope.finished++
         toastr.info "Algorithm #{item.algorithm.name} is done", 'Info'
         results.push diaModelBuilder.prepareResultForDatatable(item, res.data).result

--- a/web/app/modules/results/diaPanAndZoomManager.service.coffee
+++ b/web/app/modules/results/diaPanAndZoomManager.service.coffee
@@ -1,0 +1,68 @@
+do ->
+  'use strict'
+
+  diaPanAndZoomManager = ->
+
+    factory = ->
+      factory.paperScopes = {}
+      add: add
+      activate: activate
+      changeZoom: changeZoom
+      changeCenter: changeCenter
+      reset: reset
+
+    add = (type, id, vm) ->
+      if not factory.paperScopes[id]? then factory.paperScopes[id] = {}
+      factory.paperScopes[id][type] = vm
+      factory.paperScopes[id].active = true
+
+    activate = (id) ->
+      factory.paperScopes[id].active = true
+
+    reset = (id) ->
+      factory.paperScopes[id].active = false
+
+    changeZoom = (id, deltaY, viewPosition) ->
+      calcNewZoom = (oldZoom, delta, c, p) ->
+        factor = 1.01
+        if delta < 0
+          newZoom = oldZoom * factor
+        else if delta > 0
+          newZoom = oldZoom / factor
+        else
+          newZoom = oldZoom
+        beta = oldZoom / newZoom
+        pc = [p.x - c.x, p.y - c.y]
+        mult = [pc[0] * beta, pc[1] * beta]
+        sub = [p.x - mult[0], p.y - mult[1]]
+        a = [sub[0] - c.x, sub[1] - c.y]
+        [newZoom, a]
+
+      if factory.paperScopes[id].active and factory.paperScopes[id]['input']?
+        paperInput = factory.paperScopes[id]['input']
+        [newZoom, offset] = calcNewZoom paperInput.view.zoom, deltaY, paperInput.view.center, viewPosition
+        paperInput.view.zoom = newZoom
+        paperInput.view.center = [paperInput.view.center.x + offset[0], paperInput.view.center.y + offset[1]]
+      if factory.paperScopes[id].active and factory.paperScopes[id]['output']?
+        outputPaper = factory.paperScopes[id]['output']
+        [newZoom, offset] = calcNewZoom outputPaper.view.zoom, deltaY, outputPaper.view.center, viewPosition
+        outputPaper.view.zoom = newZoom
+        outputPaper.view.center = [outputPaper.view.center.x + offset[0], outputPaper.view.center.y + offset[1]]
+
+    changeCenter = (id, deltaX, deltaY, deltaFactor) ->
+      calcNewCenter = (oldCenter, deltaX, deltaY, factor) ->
+        offset = [deltaX * factor, -deltaY * factor]
+        newCenter = [oldCenter.x + offset[0], oldCenter.y + offset[1]]
+        newCenter
+
+      if factory.paperScopes[id].active and factory.paperScopes[id]['input']?
+        inputPaper = factory.paperScopes[id]['input']
+        inputPaper.view.center = calcNewCenter inputPaper.view.center, deltaX, deltaY, deltaFactor
+      if factory.paperScopes[id].active and factory.paperScopes[id]['output']?
+        outputPaper = factory.paperScopes[id]['output']
+        outputPaper.view.center = calcNewCenter outputPaper.view.center, deltaX, deltaY, deltaFactor
+
+    factory()
+
+  angular.module('app.results')
+    .factory 'diaPanAndZoomManager', diaPanAndZoomManager

--- a/web/app/modules/results/diaTableInputs/diaTableInputs.view.jade
+++ b/web/app/modules/results/diaTableInputs/diaTableInputs.view.jade
@@ -1,6 +1,5 @@
 h1 Input
-canvas#input-canvas(ng-if='vm.highlighter')
-img(ng-if='!vm.highlighter', ng-src='{{vm.image.path}}')
+canvas#input-canvas(ng-if='vm.image')
 .table-responsive.input-values(ng-if='vm.inputData.inputs')
   table.table.table-bordered
     thead

--- a/web/app/modules/results/diaTableOutputs/diaTableOutputs.view.jade
+++ b/web/app/modules/results/diaTableOutputs/diaTableOutputs.view.jade
@@ -1,6 +1,5 @@
 h1 Output
-canvas#output-canvas(ng-if='vm.highlighters')
-img(ng-if='!vm.highlighters && vm.image', ng-src='{{vm.image}}')
+canvas#output-canvas(ng-if='vm.image')
 .table-responsive.output-values(ng-if='vm.output')
   table.table.table-bordered
     thead

--- a/web/app/modules/results/results.view.jade
+++ b/web/app/modules/results/results.view.jade
@@ -7,19 +7,21 @@
         .text-muted(ng-if='!vm.results.length') You currently have no results. Click
           a#link(ui-sref='algorithms') here
           | to go to algorithms page.
-        table.display.projects-table.table.table-striped.table-bordered.table-hover(ng-if='vm.results.length', dia-datatable='', data-table-options='vm.tableOptions', cellspacing='0', width='100%')
-          thead
-            tr
-              th
-              th Algorithm
-              th Description
-              th Image
-              th Started
-              th Ended
-              th Duration
-          caption.smart-datatable-child-format(data-child-control='td.details-control')
-            .wrapper
-              .col-xs-12.col-lg-6
-                .table-inputs(dia-table-inputs='', data-input-data='d.input')
-              .col-xs-12.col-lg-6
-                .table-outputs(dia-table-outputs='', data-output-data='d.output')
+        span(ng-if='vm.results.length')
+          .text-muted Hold SHIFT and scroll to move input and output images around. Hold ALT and scroll to zoom in and out. Warning: If the image contains a lot of information (i.e more than 1000 points), moving or zooming might freeze your browser.
+          table.display.projects-table.table.table-striped.table-bordered.table-hover(dia-datatable='', data-table-options='vm.tableOptions', cellspacing='0', width='100%')
+            thead
+              tr
+                th
+                th Algorithm
+                th Description
+                th Image
+                th Started
+                th Ended
+                th Duration
+            caption.smart-datatable-child-format(data-child-control='td.details-control')
+              .wrapper
+                .col-xs-12.col-lg-6
+                  .table-inputs(dia-table-inputs='', data-input-data='d.input')
+                .col-xs-12.col-lg-6
+                  .table-outputs(dia-table-outputs='', data-output-data='d.output')

--- a/web/bower.json
+++ b/web/bower.json
@@ -33,7 +33,8 @@
     "paper": "0.9.22",
     "visualcaptcha.angular": "0.0.5",
     "angular-superbox": "1.0.0",
-    "moment": "2.10.3"
+    "moment": "2.10.3",
+    "jquery-mousewheel": "3.1.12"
   },
   "overrides": {
     "socket.io-client": {


### PR DESCRIPTION
* images in results page can now be moved around and zoomed in / out
* hold SHIFT and scroll to move images around
* hold ALT and scroll to zoom them in / out
* zooming or moving either the input or the output image will apply the
changes also on the other image
* WARNING: if the output image contains a lot of information (i.e. more
than 1000 points) pan and zoom may break your browser… (@lunactic maybe
we could add a check for how many highlighters the result contains and
if its exceeds the threshold, pan and zoom will be deactivated?)